### PR TITLE
feat: Improving CI compile time

### DIFF
--- a/.github/workflows/test-on-pr.yml
+++ b/.github/workflows/test-on-pr.yml
@@ -31,6 +31,7 @@ jobs:
         uses: swatinem/rust-cache@v2
         with:
           workspaces: 'packages/app/src-tauri -> target'
+          cache-directories: "packages/app/src-tauri/binaries"
 
       - name: install frontend dependencies
         run: npm install

--- a/.github/workflows/test-on-pr.yml
+++ b/.github/workflows/test-on-pr.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Rust cache
         uses: swatinem/rust-cache@v2
         with:
-          workspaces: './src-tauri -> target'
+          workspaces: 'packages/app/src-tauri -> target'
 
       - name: install frontend dependencies
         run: npm install

--- a/.github/workflows/test-on-pr.yml
+++ b/.github/workflows/test-on-pr.yml
@@ -10,29 +10,44 @@ jobs:
 
     runs-on: ${{ matrix.platform }}
     steps:
-      - uses: actions/checkout@v4
-      - name: setup node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-      - name: install Rust stable
-        uses: dtolnay/rust-toolchain@stable
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        
       - name: install dependencies (ubuntu only)
         if: matrix.platform == 'ubuntu-20.04'
         run: |
           sudo apt-get update
           sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.0-dev libappindicator3-dev librsvg2-dev patchelf
+
+      - name: setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Rust cache
+        uses: swatinem/rust-cache@v2
+        with:
+          workspaces: './src-tauri -> target'
+
       - name: install frontend dependencies
         run: npm install
+
       - name: build ui
         run: npm run build:ui
+
       - name: run typescript tests
         run: npm run test
+
       - name: rustc details
         run: rustc -vV
+
       - name: run rust tests
         run: cargo test
         working-directory: packages/app/src-tauri
+        
       - name: run rust build
         run: cargo build
         working-directory: packages/app/src-tauri

--- a/packages/app/src-tauri/src/main.rs
+++ b/packages/app/src-tauri/src/main.rs
@@ -8,7 +8,6 @@ mod utils;
 
 fn main() {
     let (level, targets, filter) = log_settings();
-
     tauri::Builder::default()
         .plugin(
             tauri_plugin_log::Builder::default()

--- a/packages/app/src-tauri/src/main.rs
+++ b/packages/app/src-tauri/src/main.rs
@@ -8,6 +8,7 @@ mod utils;
 
 fn main() {
     let (level, targets, filter) = log_settings();
+
     tauri::Builder::default()
         .plugin(
             tauri_plugin_log::Builder::default()


### PR DESCRIPTION
Most of test-on-pr action time is spent downloading and compiling rust dependencies.
It is possible to mitigate the problem by introducing a cache