### PR TITLE
feat: Abort progress task

### DIFF
--- a/packages/app/src-tauri/Cargo.lock
+++ b/packages/app/src-tauri/Cargo.lock
@@ -40,6 +40,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77c3a9648d43b9cd48db467b3f87fdd6e146bcc88ab0180006cef2179fe11d01"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -62,6 +74,12 @@ checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
 dependencies = [
  "alloc-no-stdlib",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
 
 [[package]]
 name = "android-tzdata"
@@ -666,6 +684,39 @@ dependencies = [
  "libc",
  "pkg-config",
 ]
+
+[[package]]
+name = "cached"
+version = "0.46.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c8c50262271cdf5abc979a5f76515c234e764fa025d1ba4862c0f0bcda0e95"
+dependencies = [
+ "ahash 0.8.7",
+ "cached_proc_macro",
+ "cached_proc_macro_types",
+ "hashbrown 0.14.3",
+ "instant",
+ "once_cell",
+ "thiserror",
+]
+
+[[package]]
+name = "cached_proc_macro"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c878c71c2821aa2058722038a59a67583a4240524687c6028571c9b395ded61f"
+dependencies = [
+ "darling 0.14.4",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "cached_proc_macro_types"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a4f925191b4367301851c6d99b09890311d74b0d43f274c0b34c86d308a3663"
 
 [[package]]
 name = "cairo-rs"
@@ -1527,6 +1578,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "cached",
  "derive-new",
  "function_name",
  "get_chunk",
@@ -2076,7 +2128,7 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
- "ahash",
+ "ahash 0.7.7",
 ]
 
 [[package]]
@@ -2084,6 +2136,10 @@ name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+dependencies = [
+ "ahash 0.8.7",
+ "allocator-api2",
+]
 
 [[package]]
 name = "heck"
@@ -6442,6 +6498,26 @@ dependencies = [
  "libc",
  "linux-raw-sys 0.4.12",
  "rustix 0.38.28",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.7.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.46",
 ]
 
 [[package]]

--- a/packages/app/src-tauri/Cargo.toml
+++ b/packages/app/src-tauri/Cargo.toml
@@ -23,6 +23,7 @@ zip-extract = "0.1.2"
 
 [dependencies]
 anyhow = "1.0.79"
+cached = "0.46.1"
 derive-new = "0.6.0"
 function_name = "0.3.0"
 get_chunk = { version = "1.0.0", features = ["size_format", "stream"] }
@@ -38,7 +39,7 @@ tauri = { version = "1.5", features = [ "shell-sidecar", "dialog-all", "path-all
 tauri-plugin-log = { git = "https://github.com/tauri-apps/plugins-workspace", branch = "v1" }
 tempfile = "3.8.1"
 thiserror = "1.0.52"
-tokio = { version = "1", features = ["fs"] }
+tokio = { version = "1", features = ["fs", "macros"] }
 tokio-util = {version = "0.7.10", features = ["compat"] }
 uuid = {version = "1.6.1", features = ["v7", "fast-rng", "serde",] }
 

--- a/packages/app/src-tauri/build.rs
+++ b/packages/app/src-tauri/build.rs
@@ -17,9 +17,9 @@ const X86_64_UNKNOWN_LINUX_GNU_MD5: &str =
 const X86_64_UNKNOWN_LINUX_GNU_VERSION: &str = "https://johnvansickle.com/ffmpeg";
 
 // WINDOWS SECTION
-const X86_64_PC_WINDOWS_MSVC_ARCHIVE: &'static str =
+const X86_64_PC_WINDOWS_MSVC_ARCHIVE: &str =
     "https://www.gyan.dev/ffmpeg/builds/ffmpeg-release-essentials.7z";
-const X86_64_PC_WINDOWS_MSVC_SHA256: &'static str =
+const X86_64_PC_WINDOWS_MSVC_SHA256: &str =
     "https://www.gyan.dev/ffmpeg/builds/ffmpeg-release-essentials.7z.sha256";
 const X86_64_PC_WINDOWS_MSVC_VERSION: &str = "https://www.gyan.dev/ffmpeg/builds/release-version";
 

--- a/packages/app/src-tauri/src/commands/common.rs
+++ b/packages/app/src-tauri/src/commands/common.rs
@@ -1,6 +1,22 @@
+use cached::proc_macro::cached;
 use derive_new::new;
 use getset::Getters;
 use serde::{Deserialize, Serialize};
+use tokio_util::sync::CancellationToken;
+use uuid::Uuid;
+
+use crate::utils::result::Result;
+
+#[tauri::command]
+pub async fn abort_progress_task(uuid: Uuid) -> Result<()> {
+    get_cancellation_token(uuid).cancel();
+    Ok(())
+}
+
+#[cached(sync_writes = true)]
+pub fn get_cancellation_token(_uuid: Uuid) -> CancellationToken {
+    CancellationToken::new()
+}
 
 #[derive(Deserialize, Getters, new)]
 pub struct EndPointPayloadConf {
@@ -51,6 +67,46 @@ impl FileInfo {
             size: file_info.size,
             mime_type: file_info.mime_type.clone(),
             url: format!("{}://{}/{}", protocol, endpoint_config.http_host, file_path),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::time::Duration;
+
+    use tokio::{spawn, sync::mpsc::channel, time::sleep};
+
+    use crate::{
+        commands::common::{abort_progress_task, get_cancellation_token},
+        utils::{event::EventProducer, result::Error},
+    };
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_abort_ok() {
+        let (tx, mut rx) = channel(2);
+        let mut event_producer = EventProducer::new(tx.into());
+        let original_id = event_producer.id();
+
+        spawn(async move {
+            let token = get_cancellation_token(event_producer.id());
+            sleep(Duration::from_secs(3)).await;
+            token.cancelled().await;
+            event_producer.send(Err(Error::Aborted)).await
+        });
+
+        assert!(abort_progress_task(original_id).await.is_ok());
+
+        match rx.recv().await {
+            Some((id, message)) => {
+                assert_eq!(original_id, id);
+                match message {
+                    Ok(_) => panic!("Return type must be Error::Aborted. Found {message:?}"),
+                    Err(Error::Aborted) => {}
+                    Err(_) => panic!("Return type must be Error::Aborted. Found {message:?}"),
+                }
+            }
+            None => panic!("Tx closed"),
         }
     }
 }

--- a/packages/app/src-tauri/src/main.rs
+++ b/packages/app/src-tauri/src/main.rs
@@ -28,6 +28,7 @@ fn main() {
             commands::ftp::ftp_upload_window_progress,
             commands::ftp::ftp_xml_upload,
             commands::ftp::ftp_xml_upload_window_progress,
+            commands::common::abort_progress_task,
             commands::log::log_status,
             commands::log::set_log_status,
         ])

--- a/packages/app/src-tauri/src/utils/result.rs
+++ b/packages/app/src-tauri/src/utils/result.rs
@@ -17,8 +17,10 @@ pub enum Error {
     Tauri(#[from] tauri::Error),
     #[error("Tokio channel closed")]
     TokioSendClosed,
-    #[error("Tokio task failed to execute to completion")]
+    #[error("Task failed to execute to completion")]
     TokioSet(#[from] tokio::task::JoinError),
+    #[error("Task aborted before completion")]
+    Aborted,
 }
 
 impl Serialize for Error {


### PR DESCRIPTION
The PR introduces the tauri::command `abort_progress_task` useful to stop a progress task.
The function requires the uuid of task that should be killed and always returns `Ok(())` and the killed task will return an `Err(Error::Aborted)` via its Channel 
